### PR TITLE
Improve README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+This repository provides a ROS2 + Gazebo simulator environment for ET Robocon.
+
+## Environment
+- Ubuntu 22.04
+- ROS2 Humble
+- Gazebo 11.10.2
+- Python 3.10
+
+## Development
+- Prefer Python when possible. Use C++ only for performance-critical parts.
+- Models are provided as SDF (Gazebo) and URDF (ROS2).
+
+## Documentation
+- Write documentation, code comments, and branch names in English.
+
+## Testing
+- Run `colcon test --packages-select etrobo_simulator` after making changes.

--- a/README.md
+++ b/README.md
@@ -11,20 +11,23 @@ ROS2 + Gazebo simulation environment for ET Robocon.
 ```bash
 source /opt/ros/humble/setup.bash
 colcon build --symlink-install
+source install/setup.bash
 ```
 
 ## Launch simulation
-The launch file starts Gazebo with `etrobo_world` and spawns the Spike robot model. After sourcing the setup scripts, the package automatically configures `GAZEBO_MODEL_PATH` and `GAZEBO_RESOURCE_PATH` so Gazebo can find the models.
+The `empty_world.launch.py` file loads `worlds/etrobo_world.world` and spawns the Spike robot model. Environment hooks automatically configure `GAZEBO_MODEL_PATH` and `GAZEBO_RESOURCE_PATH`.
 
 ```bash
 source /usr/share/gazebo/setup.bash
-source install/setup.bash
 ros2 launch etrobo_simulator empty_world.launch.py
 ```
 
 You can adjust the spawn position using `x_pose` and `y_pose` launch arguments:
 ```bash
-source /usr/share/gazebo/setup.bash
-source install/setup.bash
 ros2 launch etrobo_simulator empty_world.launch.py x_pose:=1.0 y_pose:=2.0
+```
+
+## Test
+```bash
+colcon test --packages-select etrobo_simulator
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # etrobo_simulator
-ros2 etrobo simulator
 
-```
-. /opt/ros/humble/setup.bash
-. /usr/share/gazebo/setup.bash
+ROS2 + Gazebo simulation environment for ET Robocon.
+
+## Requirements
+- Ubuntu 22.04
+- ROS2 Humble
+- Gazebo 11.10.2
+
+## Build
+```bash
+source /opt/ros/humble/setup.bash
 colcon build --symlink-install
-. install/setup.bash
-gazebo --verbose install/etrobo_simulator/share/etrobo_simulator/worlds/etrobo_world.world
+```
+
+## Launch simulation
+The launch file starts Gazebo with `etrobo_world` and spawns the Spike robot model. After sourcing the setup scripts, the package automatically configures `GAZEBO_MODEL_PATH` and `GAZEBO_RESOURCE_PATH` so Gazebo can find the models.
+
+```bash
+source /usr/share/gazebo/setup.bash
+source install/setup.bash
+ros2 launch etrobo_simulator empty_world.launch.py
+```
+
+You can adjust the spawn position using `x_pose` and `y_pose` launch arguments:
+```bash
+source /usr/share/gazebo/setup.bash
+source install/setup.bash
+ros2 launch etrobo_simulator empty_world.launch.py x_pose:=1.0 y_pose:=2.0
 ```


### PR DESCRIPTION
## Summary
- document how to build and launch the simulator
- show sourcing of Gazebo setup before launching

## Testing
- `colcon test --packages-select etrobo_simulator` *(fails: `colcon: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68560c89af14832f8493b8d071c6af5b